### PR TITLE
Add DelayedStakeBank

### DIFF
--- a/contracts/DelayedStakeBank.sol
+++ b/contracts/DelayedStakeBank.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.4.18;
+
+import "./StakeBank.sol";
+
+contract DelayedStakeBank is StakeBank {
+
+    uint256 unstakeDelay;
+    mapping (address => uint256) lastStake;
+
+    /// @param _token Token that can be staked.
+    /// @param _unstakeDelay Earliest time (s) after last stake that stake can be withdrawn
+    function DelayedStakeBank(ERC20 _token, uint256 _unstakeDelay) StakeBank(_token) public {
+        unstakeDelay = _unstakeDelay;
+    }
+
+    /// @notice Stakes a certain amount of tokens.
+    /// @param amount Amount of tokens to stake.
+    /// @param data Data field used for signalling in more complex staking applications.
+    function stake(uint256 amount, bytes data) public {
+        stakeFor(msg.sender, amount, data);
+    }
+
+    /// @notice Overrides StakeBank.stakeFor, to prevent denial of service
+    /// @param user Address of the user to stake for.
+    /// @param amount Amount of tokens to stake.
+    /// @param data Data field used for signalling in more complex staking applications.
+    function stakeFor(address user, uint256 amount, bytes data) public {
+        require(user == msg.sender);
+        lastStake[msg.sender] = block.timestamp;
+        StakeBank.stakeFor(user, amount, data);
+    }
+
+    /// @notice Unstakes a certain amount of tokens, if delay has passed.
+    /// @dev Overrides StakeBank.unstake
+    /// @param amount Amount of tokens to unstake.
+    /// @param data Data field used for signalling in more complex staking applications.
+    function unstake(uint256 amount, bytes data) public {
+        require(block.timestamp >= lastStake[msg.sender].add(unstakeDelay));
+        StakeBank.unstake(amount, data);
+    }
+}

--- a/contracts/DelayedStakeBank.sol
+++ b/contracts/DelayedStakeBank.sol
@@ -5,7 +5,7 @@ import "./StakeBank.sol";
 contract DelayedStakeBank is StakeBank {
 
     uint256 unstakeDelay;
-    mapping (address => uint256) lastStake;
+    mapping (address => uint256) lastStaked;
 
     /// @param _token Token that can be staked.
     /// @param _unstakeDelay Earliest time (s) after last stake that stake can be withdrawn
@@ -26,7 +26,7 @@ contract DelayedStakeBank is StakeBank {
     /// @param data Data field used for signalling in more complex staking applications.
     function stakeFor(address user, uint256 amount, bytes data) public {
         require(user == msg.sender);
-        lastStake[msg.sender] = block.timestamp;
+        lastStaked[msg.sender] = block.number;
         StakeBank.stakeFor(user, amount, data);
     }
 
@@ -35,7 +35,7 @@ contract DelayedStakeBank is StakeBank {
     /// @param amount Amount of tokens to unstake.
     /// @param data Data field used for signalling in more complex staking applications.
     function unstake(uint256 amount, bytes data) public {
-        require(block.timestamp >= lastStake[msg.sender].add(unstakeDelay));
+        require(block.number >= lastStaked[msg.sender].add(unstakeDelay));
         StakeBank.unstake(amount, data);
     }
 }

--- a/test/TestDelayedStakeBank.js
+++ b/test/TestDelayedStakeBank.js
@@ -8,7 +8,7 @@ contract('DelayedStakeBank', function (accounts) {
 
     beforeEach(async () => {
         initialBalance = 10000;
-        unstakeDelay = 1000;
+        unstakeDelay = 5;
         token = await TokenMock.new();
         bank = await DelayedStakeBank.new(token.address, unstakeDelay);
 
@@ -51,7 +51,8 @@ contract('DelayedStakeBank', function (accounts) {
         assert.equal(await bank.totalStakedFor.call(accounts[0]), initialBalance);
         assert.equal(Number(await token.balanceOf.call(accounts[0])), 0);
         assert.equal(await token.balanceOf.call(bank.address), initialBalance);
-        await utils.advanceTime(unstakeDelay);
+        const initialStakeBlock = web3.eth.blockNumber;
+        await utils.advanceToBlock(initialStakeBlock + unstakeDelay);
         await bank.unstake(initialBalance, '0x0');
         assert.equal(await bank.totalStakedFor.call(accounts[0]), 0);
         assert.equal(Number(await token.balanceOf.call(accounts[0])), initialBalance);

--- a/test/TestDelayedStakeBank.js
+++ b/test/TestDelayedStakeBank.js
@@ -1,0 +1,61 @@
+const DelayedStakeBank = artifacts.require('DelayedStakeBank.sol');
+const TokenMock = artifacts.require('./mocks/Token.sol');
+const utils = require('./helpers/Utils.js');
+
+contract('DelayedStakeBank', function (accounts) {
+
+    let bank, token, initialBalance, unstakeDelay;
+
+    beforeEach(async () => {
+        initialBalance = 10000;
+        unstakeDelay = 1000;
+        token = await TokenMock.new();
+        bank = await DelayedStakeBank.new(token.address, unstakeDelay);
+
+        await token.mint(accounts[0], initialBalance);
+        await token.mint(accounts[1], initialBalance);
+    });
+
+    it('should prevent staking for someone else', async () => {
+        const preTotalStaked = await bank.totalStakedFor.call(accounts[1]);
+        try {
+            await bank.stakeFor(accounts[1], initialBalance, '0x0', {from: accounts[0]});
+        } catch (e) {
+            const postTotalStaked = await bank.totalStakedFor.call(accounts[1]);
+            assert.equal(await token.balanceOf.call(accounts[0]), initialBalance);
+            assert.equal(Number(preTotalStaked), Number(postTotalStaked));
+            return utils.ensureException(e);
+        }
+    });
+
+    it('should not allow immediate unstake', async () => {
+        await bank.stake(initialBalance, '0x0');
+        assert.equal(await bank.totalStakedFor.call(accounts[0]), initialBalance);
+        assert.equal(Number(await token.balanceOf.call(accounts[0])), 0);
+        assert.equal(await token.balanceOf.call(bank.address), initialBalance);
+
+        try {
+            await bank.unstake(initialBalance, '0x0');
+        } catch (e) {
+            assert.equal(await bank.totalStakedFor.call(accounts[0]), initialBalance);
+            assert.equal(await token.balanceOf.call(accounts[0]), 0);
+            assert.equal(await token.balanceOf.call(bank.address), initialBalance);
+            return utils.ensureException(e);
+        }
+
+        assert.fail('immediate unstake was permitted');
+    });
+
+    it('should allow unstake after delay', async () => {
+        await bank.stake(initialBalance, '0x0');
+        assert.equal(await bank.totalStakedFor.call(accounts[0]), initialBalance);
+        assert.equal(Number(await token.balanceOf.call(accounts[0])), 0);
+        assert.equal(await token.balanceOf.call(bank.address), initialBalance);
+        await utils.advanceTime(unstakeDelay);
+        await bank.unstake(initialBalance, '0x0');
+        assert.equal(await bank.totalStakedFor.call(accounts[0]), 0);
+        assert.equal(Number(await token.balanceOf.call(accounts[0])), initialBalance);
+        assert.equal(await token.balanceOf.call(bank.address), 0);
+    });
+});
+

--- a/test/helpers/Utils.js
+++ b/test/helpers/Utils.js
@@ -29,23 +29,7 @@ async function advanceToBlock(number) {
     }
 }
 
-async function advanceTime(duration) {
-    return new Promise((resolve, reject) => {
-        web3.currentProvider.sendAsync({
-            jsonrpc: '2.0',
-            method: 'evm_increaseTime',
-            params: [duration],
-            id: Date.now(),
-        }, async (err, res) => {
-            if (err) reject(err);
-            await advanceBlock();
-            resolve(res);
-        });
-    });
-}
-
 module.exports = {
     advanceToBlock: advanceToBlock,
     ensureException: ensureException,
-    advanceTime: advanceTime,
 };

--- a/test/helpers/Utils.js
+++ b/test/helpers/Utils.js
@@ -1,3 +1,12 @@
+function isException(error) {
+    let strError = error.toString();
+    return strError.includes('invalid opcode') || strError.includes('invalid JUMP') || strError.includes('revert');
+}
+
+function ensureException(error) {
+    assert(isException(error), error.toString());
+}
+
 function advanceBlock() {
     return new Promise((resolve, reject) => {
         web3.currentProvider.sendAsync({
@@ -19,6 +28,24 @@ async function advanceToBlock(number) {
         await advanceBlock()
     }
 }
+
+async function advanceTime(duration) {
+    return new Promise((resolve, reject) => {
+        web3.currentProvider.sendAsync({
+            jsonrpc: '2.0',
+            method: 'evm_increaseTime',
+            params: [duration],
+            id: Date.now(),
+        }, async (err, res) => {
+            if (err) reject(err);
+            await advanceBlock();
+            resolve(res);
+        });
+    });
+}
+
 module.exports = {
     advanceToBlock: advanceToBlock,
+    ensureException: ensureException,
+    advanceTime: advanceTime,
 };


### PR DESCRIPTION
Rationale: Prevents `stake -> do thing -> unstake` in the same block

`user` arg in `stakeFor` was restricted to `msg.sender` to prevent unstake denial by someone calling `stakeFor` for someone else with small amounts, resetting the delay timer.

Let me know what you think!